### PR TITLE
Write env-vars to ~/.profile instead of ~/.bashrc

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -68,18 +68,16 @@ do
         git submodule update --init
         cd $OUTDIR
 
-        # Define PICO_SDK_PATH in ~/.bashrc
+        # Define PICO_XXXX_PATH in ~/.profile
         VARNAME="PICO_${REPO^^}_PATH"
-        echo "Adding $VARNAME to ~/.bashrc"
-        echo "export $VARNAME=$DEST" >> ~/.bashrc
+        echo "Adding $VARNAME to ~/.profile"
+        echo "export $VARNAME=$DEST" >> ~/.profile
         export ${VARNAME}=$DEST
     fi
 done
 
 cd $OUTDIR
 
-# Pick up new variables we just defined
-source ~/.bashrc
 
 # Build a couple of examples
 cd "$OUTDIR/pico-examples"


### PR DESCRIPTION
Fixes #13

There's also no need for `source` since we've already done `export`!