### PR TITLE
Major rewrite of pico_setup.sh

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Raspberry Pi Pico Setup
+
+Raspberry Pi Pico Setup provides a script for installing the Pico SDK and toolchain.
+
+# How-To
+
+Download and run `pico_setup.sh`.
+
+If you want the testing script and documentation, you can clone the git repo too.
+
+# Support
+
+Operating systems:
+* Raspberry Pi OS (32-bit)
+* Debian 10 (Buster)
+* Ubuntu 20.10 (Groovy)
+* macOS 11 (Big Sur)
+
+Hardware:
+* Raspberry Pi 2/3/4/400
+* PC (x86_64)
+* Mac (both Intel and Apple Silicon)
+
+Other versions may work, but haven't been tested. Use at your own risk.
+
+# Testing
+
+See [test/README.md](test/README.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ Raspberry Pi Pico Setup provides a script for installing the Pico SDK and toolch
 
 # How-To
 
+<<<<<<< HEAD
 Download and run `pico_setup.sh`.
+=======
+Download and run `pico_setup.sh`:
+```shell
+wget https://raw.githubusercontent.com/raspberrypi/pico-setup/master/pico_setup.sh
+chmod +x pico_setup
+./pico_setup
+```
+The script uses sudo, so you may need to enter your password.
+
+After the script is complete, reboot to ensure that all changes take effect, such as the UART settings and environment variables.
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 
 If you want the testing script and documentation, you can clone the git repo too.
 
@@ -17,6 +29,7 @@ Operating systems:
 * macOS 11 (Big Sur)
 
 Hardware:
+<<<<<<< HEAD
 * Raspberry Pi 2/3/4/400
 * PC (x86_64)
 * Mac (both Intel and Apple Silicon)
@@ -26,3 +39,14 @@ Other versions may work, but haven't been tested. Use at your own risk.
 # Testing
 
 See [test/README.md](test/README.md)
+=======
+* Raspberry Pi 2/3/4/400/CM3/CM4
+* PC (x86_64)
+* Mac (both Intel and Apple Silicon)
+
+Other OSes and hardware may work, but haven't been tested. Use at your own risk.
+
+# Testing
+
+See [test/README.md](test/README.md).
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Raspberry Pi Pico Setup provides a script for installing the Pico SDK and toolch
 
 # How-To
 
-<<<<<<< HEAD
-Download and run `pico_setup.sh`.
-=======
 Download and run `pico_setup.sh`:
 ```shell
 wget https://raw.githubusercontent.com/raspberrypi/pico-setup/master/pico_setup.sh
@@ -16,30 +13,24 @@ chmod +x pico_setup
 The script uses sudo, so you may need to enter your password.
 
 After the script is complete, reboot to ensure that all changes take effect, such as the UART settings and environment variables.
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 
 If you want the testing script and documentation, you can clone the git repo too.
 
 # Support
+
+This script works on most Debian-derived Linux distros and macOS, running on common Raspberry Pi, PC, and Mac hardware. This ***DOESN'T*** mean that all of the pico tools work properly on these platforms. It just means that this script runs and passes its own tests.
 
 Operating systems:
 * Raspberry Pi OS (32-bit)
 * Debian 10 (Buster)
 * Ubuntu 20.10 (Groovy)
 * macOS 11 (Big Sur)
+* Ubuntu 20.04 on Windows Subsystem for Linux on Windows Server 2019 Base
+* Debian GNU/Linux 1.3.0.0 on Windows Subsystem for Linux on Windows Server 2019 Base
+
+This script does not support Windows natively, only Windows Subsystem for Linux.
 
 Hardware:
-<<<<<<< HEAD
-* Raspberry Pi 2/3/4/400
-* PC (x86_64)
-* Mac (both Intel and Apple Silicon)
-
-Other versions may work, but haven't been tested. Use at your own risk.
-
-# Testing
-
-See [test/README.md](test/README.md)
-=======
 * Raspberry Pi 2/3/4/400/CM3/CM4
 * PC (x86_64)
 * Mac (both Intel and Apple Silicon)
@@ -49,4 +40,3 @@ Other OSes and hardware may work, but haven't been tested. Use at your own risk.
 # Testing
 
 See [test/README.md](test/README.md).
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.

--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -20,7 +20,6 @@
 # Download and install Visual Studio Code and required extensions
 
 
-
 # Exit on error
 set -e
 # Show all commands
@@ -112,7 +111,7 @@ phase_0() {
 install_toolchain_linux() {
     # Install toolchain for Linux
 
-    DEPS="git cmake gcc-arm-none-eabi build-essential gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
+    DEPS="python3 git cmake gcc-arm-none-eabi build-essential gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
     if debian || ubuntu; then
         DEPS="${DEPS} pkg-config libstdc++-arm-none-eabi-newlib"
     fi
@@ -172,9 +171,10 @@ clone_repo() {
     fi
 }
 
-set_envs() {
-    # Permanently sets environment variables by adding them to the current user's profile script
-    # arguments should be in the form of FOO=foo BAR=bar
+set_env() {
+    # Permanently sets an environment variable by adding it to the current user's profile script
+    # $1 should be in the form of FOO=foo
+    EXPR="${1}"
 
     # detect appropriate file for setting env vars
     if echo "${SHELL}" | grep -q zsh; then
@@ -186,25 +186,23 @@ set_envs() {
     fi
 
     # ensure that appends go to a new line
-    if [ -f ${FILE} ]; then
-        if tail -n 1 ${FILE} | grep -q "^$"; then
+    if [ -f "${FILE}" ]; then
+        if tail -n 1 "${FILE}" | grep -q "^$"; then
             echo "${FILE} exists and has trailing newline."
         else
             echo "${FILE} exists but has no trailing newline. Adding newline."
-            echo >> ${FILE}
+            echo >> "${FILE}"
         fi
     fi
 
-    for EXPR in ${*}; do
-        # set for now
-        export "${EXPR}"
-        
-        # set for later
-        if ! grep -q "^export ${EXPR}$" ${FILE}; then
-            echo "Setting env variable ${EXPR} in ${FILE}"
-            echo "export ${EXPR}" >> ${FILE}
-        fi
-    done
+    # set for now
+    export "${EXPR}"
+    
+    # set for later
+    if ! grep -q "^export ${EXPR}$" "${FILE}"; then
+        echo "Setting env variable ${EXPR} in ${FILE}"
+        echo "export \"${EXPR}\"" >> "${FILE}"
+    fi
 }
 
 setup_sdk() {
@@ -216,7 +214,7 @@ setup_sdk() {
     # Set env var PICO_SDK_PATH
     REPO_UPPER=$(echo ${REPO_NAME} | tr "[:lower:]" "[:upper:]")
     REPO_UPPER=$(echo ${REPO_UPPER} | tr "-" "_")
-    set_envs "${REPO_UPPER}_PATH=$DEST"
+    set_env "${REPO_UPPER}_PATH=$DEST"
 }
 
 enable_uart() {

--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -1,186 +1,396 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Phase 0: Preflight check
+# Verify baseline dependencies
+
+# Phase 1: Setup minimum dev environment
+# Install the toolchain
+# Create a directory called pico
+# Download the pico-sdk repository and submodules
+# Define env variables for repo: PICO_SDK_PATH
+# Configure the Raspberry Pi UART for use with Raspberry Pi Pico
+
+# Phase 2: Setting up tutorial repos
+# Download pico-examples, pico-extras, pico-playground repositories, and submodules
+# Build the blink and hello_world examples
+
+# Phase 3: Recommended tools
+# Download and build picotool (see Appendix B), and copy it to /usr/local/bin.
+# Download and build picoprobe (see Appendix A) and OpenOCD
+# Download and install Visual Studio Code and required extensions
+
+
 
 # Exit on error
 set -e
+# Show all commands
+set -x
 
-if grep -q Raspberry /proc/cpuinfo; then
-    echo "Running on a Raspberry Pi"
-else
-    echo "Not running on a Raspberry Pi. Use at your own risk!"
-fi
 
 # Number of cores when running make
 JNUM=4
 
 # Where will the output go?
-OUTDIR="$(pwd)/pico"
+WORKING_DIR="$(pwd)/pico"
 
-# Install dependencies
-GIT_DEPS="git"
-SDK_DEPS="cmake gcc-arm-none-eabi gcc g++"
-OPENOCD_DEPS="gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
-# Wget to download the deb
-VSCODE_DEPS="wget"
-UART_DEPS="minicom"
 
-# Build full list of dependencies
-DEPS="$GIT_DEPS $SDK_DEPS"
+linux() {
+    # Returns true iff this is running on Linux
+    uname | grep -q "^Linux$"
+    return ${?}
+}
 
-if [[ "$SKIP_OPENOCD" == 1 ]]; then
-    echo "Skipping OpenOCD (debug support)"
-else
-    DEPS="$DEPS $OPENOCD_DEPS"
-fi
+raspbian() {
+    # Returns true iff this is running on Raspbian or close derivative such as Raspberry Pi OS, but not necessarily on a Raspberry Pi computer
+    grep -q '^NAME="Raspbian GNU/Linux"$' /etc/os-release
+    return ${?}
+}
 
-if [[ "$SKIP_VSCODE" == 1 ]]; then
-    echo "Skipping VSCODE"
-else
-    DEPS="$DEPS $VSCODE_DEPS"
-fi
+debian() {
+    # Returns true iff this is running on Debian
+    grep -q '^NAME="Debian GNU/Linux"$' /etc/os-release
+    return ${?}
+}
 
-echo "Installing Dependencies"
-sudo apt update
-sudo apt install -y $DEPS
+ubuntu() {
+    # Returns true iff this is running on Ubuntu
+    grep -q '^NAME="Ubuntu"$' /etc/os-release
+    return ${?}
+}
 
-echo "Creating $OUTDIR"
-# Create pico directory to put everything in
-mkdir -p $OUTDIR
-cd $OUTDIR
+mac() {
+    # Returns true iff this is running on macOS and presumably Apple hardware
+    uname | grep -q "^Darwin$"
+    return ${?}
+}
 
-# Clone sw repos
-GITHUB_PREFIX="https://github.com/raspberrypi/"
-GITHUB_SUFFIX=".git"
-SDK_BRANCH="master"
-
-for REPO in sdk examples extras playground
-do
-    DEST="$OUTDIR/pico-$REPO"
-
-    if [ -d $DEST ]; then
-        echo "$DEST already exists so skipping"
-    else
-        REPO_URL="${GITHUB_PREFIX}pico-${REPO}${GITHUB_SUFFIX}"
-        echo "Cloning $REPO_URL"
-        git clone -b $SDK_BRANCH $REPO_URL
-
-        # Any submodules
-        cd $DEST
-        git submodule update --init
-        cd $OUTDIR
-
-        # Define PICO_SDK_PATH in ~/.bashrc
-        VARNAME="PICO_${REPO^^}_PATH"
-        echo "Adding $VARNAME to ~/.bashrc"
-        echo "export $VARNAME=$DEST" >> ~/.bashrc
-        export ${VARNAME}=$DEST
+raspberry_pi() {
+    # Returns true iff this is running on a Raspberry Pi computer, regardless of the OS
+    if [ -f /proc/cpuinfo ]; then
+        grep -q "^Model\s*: Raspberry Pi" /proc/cpuinfo
+        return ${?}
     fi
-done
+    return 1
+}
 
-cd $OUTDIR
+phase_0() {
+    # Preflight the check
+    # Checks the baseline dependencies. If you don't have these, this script won't work.
+    echo "Entering phase 0: Preflight check"
+    
+    echo "Verifying sudo access"
+    sudo -v
 
-# Pick up new variables we just defined
-source ~/.bashrc
-
-# Build a couple of examples
-cd "$OUTDIR/pico-examples"
-mkdir build
-cd build
-cmake ../ -DCMAKE_BUILD_TYPE=Debug
-
-for e in blink hello_world
-do
-    echo "Building $e"
-    cd $e
-    make -j$JNUM
-    cd ..
-done
-
-cd $OUTDIR
-
-# Picoprobe and picotool
-for REPO in picoprobe picotool
-do
-    DEST="$OUTDIR/$REPO"
-    REPO_URL="${GITHUB_PREFIX}${REPO}${GITHUB_SUFFIX}"
-    git clone $REPO_URL
-
-    # Build both
-    cd $DEST
-    mkdir build
-    cd build
-    cmake ../
-    make -j$JNUM
-
-    if [[ "$REPO" == "picotool" ]]; then
-        echo "Installing picotool to /usr/local/bin/picotool"
-        sudo cp picotool /usr/local/bin/
-    fi
-
-    cd $OUTDIR
-done
-
-if [ -d openocd ]; then
-    echo "openocd already exists so skipping"
-    SKIP_OPENOCD=1
-fi
-
-if [[ "$SKIP_OPENOCD" == 1 ]]; then
-    echo "Won't build OpenOCD"
-else
-    # Build OpenOCD
-    echo "Building OpenOCD"
-    cd $OUTDIR
-    # Should we include picoprobe support (which is a Pico acting as a debugger for another Pico)
-    INCLUDE_PICOPROBE=1
-    OPENOCD_BRANCH="rp2040"
-    OPENOCD_CONFIGURE_ARGS="--enable-ftdi --enable-sysfsgpio --enable-bcm2835gpio"
-    if [[ "$INCLUDE_PICOPROBE" == 1 ]]; then
-        OPENOCD_BRANCH="picoprobe"
-        OPENOCD_CONFIGURE_ARGS="$OPENOCD_CONFIGURE_ARGS --enable-picoprobe"
-    fi
-
-    git clone "${GITHUB_PREFIX}openocd${GITHUB_SUFFIX}" -b $OPENOCD_BRANCH --depth=1
-    cd openocd
-    ./bootstrap
-    ./configure $OPENOCD_CONFIGURE_ARGS
-    make -j$JNUM
-    sudo make install
-fi
-
-cd $OUTDIR
-
-# Liam needed to install these to get it working
-EXTRA_VSCODE_DEPS="libx11-xcb1 libxcb-dri3-0 libdrm2 libgbm1 libegl-mesa0"
-if [[ "$SKIP_VSCODE" == 1 ]]; then
-    echo "Won't include VSCODE"
-else
-    if [ -f vscode.deb ]; then
-        echo "Skipping vscode as vscode.deb exists"
-    else
-        echo "Installing VSCODE"
-        if uname -m | grep -q aarch64; then
-            VSCODE_DEB="https://aka.ms/linux-arm64-deb"
+    if mac; then
+        echo "Running on macOS"
+        if which brew >> /dev/null; then
+            echo "Found brew"
+            brew update
         else
-            VSCODE_DEB="https://aka.ms/linux-armhf-deb"
+            echo -e 'This script requires Homebrew, the missing package manager for macOS. See https://docs.brew.sh/Installation. For quick install, run:\n/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
+            echo "Stopping."
+            exit 1
+        fi
+    else
+        if linux; then
+            echo "Running on Linux"
+        else
+            echo "Platform $(uname) not recognized. Use at your own risk. Continuing as though this were Linux."
         fi
 
-        wget -O vscode.deb $VSCODE_DEB
-        sudo apt install -y ./vscode.deb
-        sudo apt install -y $EXTRA_VSCODE_DEPS
-
-        # Get extensions
-        code --install-extension marus25.cortex-debug
-        code --install-extension ms-vscode.cmake-tools
-        code --install-extension ms-vscode.cpptools
+        if which apt >> /dev/null; then
+            echo "Found apt"
+            sudo apt update
+        else
+            echo 'This script requires apt, the default package manager for Debian and Debian-derived distros such as Ubuntu, and Raspberry Pi OS.'
+            echo "Stopping."
+            exit 1
+        fi
     fi
-fi
+}
 
-# Enable UART
-if [[ "$SKIP_UART" == 1 ]]; then
-    echo "Skipping uart configuration"
-else
-    sudo apt install -y $UART_DEPS
+install_toolchain_linux() {
+    # Install toolchain for Linux
+
+    DEPS="git cmake gcc-arm-none-eabi build-essential gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
+    if debian || ubuntu; then
+        DEPS="${DEPS} pkg-config libstdc++-arm-none-eabi-newlib"
+    fi
+    sudo apt install -y ${DEPS}
+}
+
+brew_install_idempotent() {
+    # For some reason, brew install is not idempotent. This function succeeds even when the package is already installed.
+    brew list ${*} || brew install ${*}
+    return ${?}
+}
+
+install_toolchain_mac() {
+    # Install dependencies for mac
+
+    brew_install_idempotent git cmake pkg-config libtool automake libusb wget pkg-config gcc texinfo
+    brew tap ArmMbed/homebrew-formulae
+    brew_install_idempotent arm-none-eabi-gcc
+}
+
+create_working_dir() {
+    # Creates ./pico directory if necessary
+
+    mkdir -p "${WORKING_DIR}"
+}
+
+clone_repo() {
+    # Clones the given repo name from GitHub and inits any submodules
+    # $1 should be the full name of the repo, ex: pico-sdk
+    # $2 should be the branch name. Defaults to master.
+    # all other args are passed to git clone
+    REPO_NAME="${1}"
+    if shift && [ "${1}" ]; then
+        BRANCH="${1}"
+    else
+        BRANCH=master
+    fi
+    if shift; then
+        # $* contains more args
+        true
+    fi
+
+    cd "${WORKING_DIR}"
+
+    REPO_URL="https://github.com/raspberrypi/${REPO_NAME}.git"
+    DEST="${WORKING_DIR}/${REPO_NAME}"
+
+    if [ -d "${DEST}" ]; then
+        echo "Not cloning $DEST because it already exists"
+    else
+        echo "Cloning $REPO_URL"
+        git clone -b "$BRANCH" "$REPO_URL" ${*}
+
+        # Any submodules
+        cd "$DEST"
+        git submodule update --init
+    fi
+}
+
+set_envs() {
+    # Permanently sets environment variables by adding them to the current user's profile script
+    # arguments should be in the form of FOO=foo BAR=bar
+
+    # detect appropriate file for setting env vars
+    if echo "${SHELL}" | grep -q zsh; then
+        # zsh detected
+        FILE=~/.zprofile
+    else
+        # sh, bash and others
+        FILE=~/.profile
+    fi
+
+    # ensure that appends go to a new line
+    if [ -f ${FILE} ]; then
+        if tail -n 1 ${FILE} | grep -q "^$"; then
+            echo "${FILE} exists and has trailing newline."
+        else
+            echo "${FILE} exists but has no trailing newline. Adding newline."
+            echo >> ${FILE}
+        fi
+    fi
+
+    for EXPR in ${*}; do
+        # set for now
+        export "${EXPR}"
+        
+        # set for later
+        set_env "${FILE}" "${EXPR}"
+    done
+}
+
+set_env() {
+    # Permanently sets one environment variable for bash
+    # $1 must be the file where the env is stored
+    # $2 should be in the form of VAR=value
+    FILE="${1}"
+    EXPR="${2}"
+
+    if ! grep -q "^export ${EXPR}$" ${FILE}; then
+        echo "Setting env variable ${EXPR} in ${FILE}"
+        echo "export ${EXPR}" >> ${FILE}
+    fi
+}
+
+setup_sdk() {
+    # Downloads and builds the SDK
+    cd "${WORKING_DIR}"
+
+    clone_repo pico-sdk
+
+    # Set env var PICO_SDK_PATH
+    REPO_UPPER=$(echo ${REPO_NAME} | tr "[:lower:]" "[:upper:]")
+    REPO_UPPER=$(echo ${REPO_UPPER} | tr "-" "_")
+    set_envs "${REPO_UPPER}_PATH=$DEST"
+}
+
+enable_uart() {
+    # Enable UART
+    sudo apt install -y minicom
     echo "Disabling Linux serial console (UART) so we can use it for pico"
     sudo raspi-config nonint do_serial 2
     echo "You must run sudo reboot to finish UART setup"
-fi
+}
+
+phase_1() {
+    # Setup minimum dev environment
+    echo "Entering phase 1: Setup minimum dev environment"
+
+    if mac; then
+        install_toolchain_mac
+    else
+        install_toolchain_linux
+    fi
+
+    create_working_dir
+    setup_sdk
+
+    if linux && pi; then
+        if [[ "$SKIP_UART" == 1 ]]; then
+            echo "Skipping UART configuration"
+        else
+            enable_uart
+        fi
+    else
+        echo "Not configuring UART because this is not running Raspberry Pi OS on a Raspberry Pi computer"
+    fi
+}
+
+build_examples() {
+    # Build a couple of examples
+    echo "Building selected examples"
+    
+    cd "$WORKING_DIR/pico-examples"
+    mkdir -p build
+    cd build
+    cmake ../ -DCMAKE_BUILD_TYPE=Debug
+
+    for EXAMPLE in blink hello_world; do
+        echo "Building $EXAMPLE"
+        cd "$EXAMPLE"
+        make -j${JNUM}
+        cd ..
+    done
+}
+
+phase_2() {
+    # Setup tutorial repos
+    echo "Entering phase 2: Setting up tutorial repos"
+
+    for REPO_NAME in pico-examples pico-extras pico-playground; do
+        clone_repo "${REPO_NAME}"
+    done
+
+    build_examples
+}
+
+setup_picotool() {
+    # Downloads, builds, and installs picotool
+    echo "Setting up picotool"
+
+    cd "${WORKING_DIR}"
+
+    clone_repo picotool
+    cd "${WORKING_DIR}/picotool"
+    mkdir -p build
+    cd build
+    cmake ../
+    make -j${JNUM}
+
+    echo "Installing picotool to /usr/local/bin/picotool"
+    sudo cp picotool /usr/local/bin/
+}
+
+setup_openocd() {
+    # Download, build, and install OpenOCD for picoprobe and bit-banging without picoprobe
+    echo "Setting up OpenOCD"
+
+    cd "${WORKING_DIR}"
+
+    clone_repo openocd picoprobe --depth=1
+    cd "${WORKING_DIR}/openocd"
+    ./bootstrap
+    OPTS="--enable-ftdi --enable-bcm2835gpio  --enable-picoprobe"
+    if linux; then
+        # sysfsgpio is only available on linux
+        OPTS="${OPTS} --enable-sysfsgpio"
+    fi
+    ./configure ${OPTS}
+    make -j${JNUM}
+    sudo make install
+}
+
+setup_picoprobe() {
+    # Download and build picoprobe. Requires that OpenOCD is already setup
+    echo "Setting up picoprobe"
+
+    cd "${WORKING_DIR}"
+
+    clone_repo picoprobe
+    cd "${WORKING_DIR}/picoprobe"
+    mkdir -p build
+    cd build
+    cmake ..
+    make -j${JNUM}
+}
+
+install_vscode_linux() {
+    # Install Visual Studio Code
+
+    # VS Code is specially added to Raspberry Pi OS repos. Need to add the right repos to make it work on Debian/Ubuntu.
+    if debian || ubuntu; then
+        echo "Visual Studio Code installation currently doesn't work on Debian and Ubuntu"
+        return
+    fi
+
+    echo "Installing Visual Studio Code"
+
+    cd "${WORKING_DIR}"
+
+    sudo apt install -y code
+
+    # Get extensions
+    code --install-extension marus25.cortex-debug
+    code --install-extension ms-vscode.cmake-tools
+    code --install-extension ms-vscode.cpptools
+}
+
+install_vscode_mac() {
+    echo "This script cannot install Visual Studio Code on macOS"
+}
+
+phase_3() {
+    # Setup recommended tools
+    echo "Setting up recommended tools"
+
+    setup_picotool
+    setup_openocd
+    setup_picoprobe
+
+    # Install Visual Studio Code
+    if mac; then
+        install_vscode_mac
+    else
+        if dpkg-query -s libx11-6; then
+            install_vscode_linux
+        else
+            echo "Not installing Visual Studio Code because it looks like XWindows is not installed."
+        fi
+    fi
+}
+
+main() {
+    phase_0
+    phase_1
+    phase_2
+    phase_3
+
+    echo "Congratulations, installation is complete. 😁"
+}
+
+main

--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -161,23 +161,6 @@ clone_repo() {
     DEST="${WORKING_DIR}/${REPO_NAME}"
 
     if [ -d "${DEST}" ]; then
-<<<<<<< HEAD
-        echo "Not cloning $DEST because it already exists"
-    else
-        echo "Cloning $REPO_URL"
-        git clone -b "$BRANCH" "$REPO_URL" ${*}
-
-        # Any submodules
-        cd "$DEST"
-        git submodule update --init
-    fi
-}
-
-set_envs() {
-    # Permanently sets environment variables by adding them to the current user's profile script
-    # arguments should be in the form of FOO=foo BAR=bar
-
-=======
         echo "Not cloning ${DEST} because it already exists. If you really want to start over, delete it: rm -rf ${DEST}"
     else
         echo "Cloning ${REPO_URL}"
@@ -193,7 +176,6 @@ set_envs() {
     # Permanently sets environment variables by adding them to the current user's profile script
     # arguments should be in the form of FOO=foo BAR=bar
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     # detect appropriate file for setting env vars
     if echo "${SHELL}" | grep -q zsh; then
         # zsh detected
@@ -218,120 +200,6 @@ set_envs() {
         export "${EXPR}"
         
         # set for later
-<<<<<<< HEAD
-        set_env "${FILE}" "${EXPR}"
-    done
-}
-
-set_env() {
-    # Permanently sets one environment variable for bash
-    # $1 must be the file where the env is stored
-    # $2 should be in the form of VAR=value
-    FILE="${1}"
-    EXPR="${2}"
-
-    if ! grep -q "^export ${EXPR}$" ${FILE}; then
-        echo "Setting env variable ${EXPR} in ${FILE}"
-        echo "export ${EXPR}" >> ${FILE}
-    fi
-}
-
-setup_sdk() {
-    # Downloads and builds the SDK
-    cd "${WORKING_DIR}"
-
-    clone_repo pico-sdk
-
-    # Set env var PICO_SDK_PATH
-    REPO_UPPER=$(echo ${REPO_NAME} | tr "[:lower:]" "[:upper:]")
-    REPO_UPPER=$(echo ${REPO_UPPER} | tr "-" "_")
-    set_envs "${REPO_UPPER}_PATH=$DEST"
-}
-
-enable_uart() {
-    # Enable UART
-    sudo apt install -y minicom
-    echo "Disabling Linux serial console (UART) so we can use it for pico"
-    sudo raspi-config nonint do_serial 2
-    echo "You must run sudo reboot to finish UART setup"
-}
-
-phase_1() {
-    # Setup minimum dev environment
-    echo "Entering phase 1: Setup minimum dev environment"
-
-    if mac; then
-        install_toolchain_mac
-    else
-        install_toolchain_linux
-    fi
-
-    create_working_dir
-    setup_sdk
-
-    if linux && pi; then
-        if [[ "$SKIP_UART" == 1 ]]; then
-            echo "Skipping UART configuration"
-        else
-            enable_uart
-        fi
-    else
-        echo "Not configuring UART because this is not running Raspberry Pi OS on a Raspberry Pi computer"
-    fi
-}
-
-build_examples() {
-    # Build a couple of examples
-    echo "Building selected examples"
-    
-    cd "$WORKING_DIR/pico-examples"
-    mkdir -p build
-    cd build
-    cmake ../ -DCMAKE_BUILD_TYPE=Debug
-
-    for EXAMPLE in blink hello_world; do
-        echo "Building $EXAMPLE"
-        cd "$EXAMPLE"
-        make -j${JNUM}
-        cd ..
-    done
-}
-
-phase_2() {
-    # Setup tutorial repos
-    echo "Entering phase 2: Setting up tutorial repos"
-
-    for REPO_NAME in pico-examples pico-extras pico-playground; do
-        clone_repo "${REPO_NAME}"
-    done
-
-    build_examples
-}
-
-setup_picotool() {
-    # Downloads, builds, and installs picotool
-    echo "Setting up picotool"
-
-    cd "${WORKING_DIR}"
-
-    clone_repo picotool
-    cd "${WORKING_DIR}/picotool"
-    mkdir -p build
-    cd build
-    cmake ../
-    make -j${JNUM}
-
-    echo "Installing picotool to /usr/local/bin/picotool"
-    sudo cp picotool /usr/local/bin/
-}
-
-setup_openocd() {
-    # Download, build, and install OpenOCD for picoprobe and bit-banging without picoprobe
-    echo "Setting up OpenOCD"
-
-    cd "${WORKING_DIR}"
-
-=======
         if ! grep -q "^export ${EXPR}$" ${FILE}; then
             echo "Setting env variable ${EXPR} in ${FILE}"
             echo "export ${EXPR}" >> ${FILE}
@@ -430,7 +298,6 @@ setup_openocd() {
 
     cd "${WORKING_DIR}"
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     clone_repo openocd picoprobe --depth=1
     cd "${WORKING_DIR}/openocd"
     ./bootstrap
@@ -463,28 +330,16 @@ install_vscode_linux() {
 
     # VS Code is specially added to Raspberry Pi OS repos. Need to add the right repos to make it work on Debian/Ubuntu.
     if debian || ubuntu; then
-<<<<<<< HEAD
-        echo "Visual Studio Code installation currently doesn't work on Debian and Ubuntu"
-=======
         echo "Not yet implemented: testing Visual Studio Code on Debian/Ubuntu"
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
         return
     fi
 
     echo "Installing Visual Studio Code"
-<<<<<<< HEAD
 
     cd "${WORKING_DIR}"
 
     sudo apt install -y code
 
-=======
-
-    cd "${WORKING_DIR}"
-
-    sudo apt install -y code
-
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     # Get extensions
     code --install-extension marus25.cortex-debug
     code --install-extension ms-vscode.cmake-tools
@@ -492,11 +347,7 @@ install_vscode_linux() {
 }
 
 install_vscode_mac() {
-<<<<<<< HEAD
-    echo "This script cannot install Visual Studio Code on macOS"
-=======
     echo "Not yet implemented: installing Visual Studio Code on macOS"
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 }
 
 phase_3() {
@@ -511,11 +362,7 @@ phase_3() {
     if mac; then
         install_vscode_mac
     else
-<<<<<<< HEAD
-        if dpkg-query -s libx11-6; then
-=======
         if dpkg-query -s xserver-xorg >> /dev/null; then
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
             install_vscode_linux
         else
             echo "Not installing Visual Studio Code because it looks like XWindows is not installed."
@@ -532,8 +379,4 @@ main() {
     echo "Congratulations, installation is complete. 😁"
 }
 
-<<<<<<< HEAD
 main
-=======
-main
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.

--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -161,6 +161,7 @@ clone_repo() {
     DEST="${WORKING_DIR}/${REPO_NAME}"
 
     if [ -d "${DEST}" ]; then
+<<<<<<< HEAD
         echo "Not cloning $DEST because it already exists"
     else
         echo "Cloning $REPO_URL"
@@ -176,6 +177,23 @@ set_envs() {
     # Permanently sets environment variables by adding them to the current user's profile script
     # arguments should be in the form of FOO=foo BAR=bar
 
+=======
+        echo "Not cloning ${DEST} because it already exists. If you really want to start over, delete it: rm -rf ${DEST}"
+    else
+        echo "Cloning ${REPO_URL}"
+        git clone -b "${BRANCH}" "${REPO_URL}" ${*}
+
+        # Any submodules
+        cd "${DEST}"
+        git submodule update --init
+    fi
+}
+
+set_envs() {
+    # Permanently sets environment variables by adding them to the current user's profile script
+    # arguments should be in the form of FOO=foo BAR=bar
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     # detect appropriate file for setting env vars
     if echo "${SHELL}" | grep -q zsh; then
         # zsh detected
@@ -200,6 +218,7 @@ set_envs() {
         export "${EXPR}"
         
         # set for later
+<<<<<<< HEAD
         set_env "${FILE}" "${EXPR}"
     done
 }
@@ -312,6 +331,106 @@ setup_openocd() {
 
     cd "${WORKING_DIR}"
 
+=======
+        if ! grep -q "^export ${EXPR}$" ${FILE}; then
+            echo "Setting env variable ${EXPR} in ${FILE}"
+            echo "export ${EXPR}" >> ${FILE}
+        fi
+    done
+}
+
+setup_sdk() {
+    # Downloads and builds the SDK
+    cd "${WORKING_DIR}"
+
+    clone_repo pico-sdk
+
+    # Set env var PICO_SDK_PATH
+    REPO_UPPER=$(echo ${REPO_NAME} | tr "[:lower:]" "[:upper:]")
+    REPO_UPPER=$(echo ${REPO_UPPER} | tr "-" "_")
+    set_envs "${REPO_UPPER}_PATH=$DEST"
+}
+
+enable_uart() {
+    # Enable UART
+    sudo apt install -y minicom
+    echo "Disabling Linux serial console (UART) so we can use it for pico"
+    sudo raspi-config nonint do_serial 2
+    echo "You must run sudo reboot to finish UART setup"
+}
+
+phase_1() {
+    # Setup minimum dev environment
+    echo "Entering phase 1: Setup minimum dev environment"
+
+    if mac; then
+        install_toolchain_mac
+    else
+        install_toolchain_linux
+    fi
+
+    create_working_dir
+    setup_sdk
+
+    if raspbian && raspberry_pi; then
+        enable_uart
+    else
+        echo "Not configuring UART because this is not running Raspberry Pi OS on a Raspberry Pi computer"
+    fi
+}
+
+build_examples() {
+    # Build a couple of examples
+    echo "Building selected examples"
+    
+    cd "$WORKING_DIR/pico-examples"
+    mkdir -p build
+    cd build
+    cmake ../ -DCMAKE_BUILD_TYPE=Debug
+
+    for EXAMPLE in blink hello_world; do
+        echo "Building $EXAMPLE"
+        cd "$EXAMPLE"
+        make -j${JNUM}
+        cd ..
+    done
+}
+
+phase_2() {
+    # Setup tutorial repos
+    echo "Entering phase 2: Setting up tutorial repos"
+
+    for REPO_NAME in pico-examples pico-extras pico-playground; do
+        clone_repo "${REPO_NAME}"
+    done
+
+    build_examples
+}
+
+setup_picotool() {
+    # Downloads, builds, and installs picotool
+    echo "Setting up picotool"
+
+    cd "${WORKING_DIR}"
+
+    clone_repo picotool
+    cd "${WORKING_DIR}/picotool"
+    mkdir -p build
+    cd build
+    cmake ../
+    make -j${JNUM}
+
+    echo "Installing picotool to /usr/local/bin/picotool"
+    sudo cp picotool /usr/local/bin/
+}
+
+setup_openocd() {
+    # Download, build, and install OpenOCD for picoprobe and bit-banging without picoprobe
+    echo "Setting up OpenOCD"
+
+    cd "${WORKING_DIR}"
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     clone_repo openocd picoprobe --depth=1
     cd "${WORKING_DIR}/openocd"
     ./bootstrap
@@ -344,16 +463,28 @@ install_vscode_linux() {
 
     # VS Code is specially added to Raspberry Pi OS repos. Need to add the right repos to make it work on Debian/Ubuntu.
     if debian || ubuntu; then
+<<<<<<< HEAD
         echo "Visual Studio Code installation currently doesn't work on Debian and Ubuntu"
+=======
+        echo "Not yet implemented: testing Visual Studio Code on Debian/Ubuntu"
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
         return
     fi
 
     echo "Installing Visual Studio Code"
+<<<<<<< HEAD
 
     cd "${WORKING_DIR}"
 
     sudo apt install -y code
 
+=======
+
+    cd "${WORKING_DIR}"
+
+    sudo apt install -y code
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
     # Get extensions
     code --install-extension marus25.cortex-debug
     code --install-extension ms-vscode.cmake-tools
@@ -361,7 +492,11 @@ install_vscode_linux() {
 }
 
 install_vscode_mac() {
+<<<<<<< HEAD
     echo "This script cannot install Visual Studio Code on macOS"
+=======
+    echo "Not yet implemented: installing Visual Studio Code on macOS"
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 }
 
 phase_3() {
@@ -376,7 +511,11 @@ phase_3() {
     if mac; then
         install_vscode_mac
     else
+<<<<<<< HEAD
         if dpkg-query -s libx11-6; then
+=======
+        if dpkg-query -s xserver-xorg >> /dev/null; then
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
             install_vscode_linux
         else
             echo "Not installing Visual Studio Code because it looks like XWindows is not installed."
@@ -393,4 +532,8 @@ main() {
     echo "Congratulations, installation is complete. 😁"
 }
 
+<<<<<<< HEAD
 main
+=======
+main
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.

--- a/test/README.md
+++ b/test/README.md
@@ -18,21 +18,21 @@ Test support for the following platforms. The general process is:
 1. Start from a fresh OS image.
 1. Start the SSH service if necessary: `sudo /sbin/service ssh start`
 1. Push down the contents of the pico-setup repo from your dev host: `scp -r ~/git/raspberrypi/pico-setup/ pi@pi4:`
-1. SSH to the test host and execute the setup: `pico-setup/pico_setup.sh`
-1. Test the setup: "ssh pi@pi4 pico-setup/test/test"
+1. SSH to the test host and execute the setup: `ssh pi@pi4 pico-setup/pico_setup.sh`
+1. Logout to pick up env variables and test the setup: `ssh pi@pi4 pico-setup/test/test`
 
-### Raspberry Pi OS Full (32-bit) on Raspberry Pi 4B
+### Raspberry Pi OS (32-bit) on Raspberry Pi 4B
 This is the baseline platform, what most users will have.
 
 Write fresh SD card with Raspberry Pi Imager.
 
-### Raspberry Pi OS Full (64-bit) on Raspberry Pi 4B
+### Raspberry Pi OS (64-bit) on Raspberry Pi 4B
 If all of the dependencies (APT repo, etc) are in good shape, this should work the same as the 32-bit OS, since we don't do anything explicitly for one or the other.
 
 Write fresh SD card with Raspberry Pi Imager.
 
 ### Raspberry Pi OS Lite (32-bit) on Raspberry Pi 4B
-Should be the same as the full OS, but doesn't attempt to install VS Code, because there will be no XWindows.
+Should be the same as the full OS. Currently, this will install Visual Studio Code, but that may change.
 
 Write fresh SD card with Raspberry Pi Imager.
 
@@ -80,20 +80,27 @@ passwd ubuntu
 ```
 
 ### Debian 10 (Buster) on Graviton2
-Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B0859NK4HC?ref_=aws-mp-console-subscription-detail) for pennies/hour. Recommend t3.micro with 8 GiB EBS volume. Default user is `admin`. You will have to use sudo to set the user's password:
+Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B0859NK4HC?ref_=aws-mp-console-subscription-detail) for pennies/hour. Recommend t4g.micro with 8 GiB EBS volume. Default user is `admin`. You will have to use sudo to set the user's password:
 ```shell
 sudo -i
 passwd admin
 ```
 
 ### Windows Server 2016 Base on x86_64
-https://aws.amazon.com/marketplace/server/procurement?productId=13c2dbc9-57fc-4958-922e-a1ba7e223b0d
+Not yet tested. See https://aws.amazon.com/marketplace/server/procurement?productId=13c2dbc9-57fc-4958-922e-a1ba7e223b0d.
 
-### Windows Server 2016 Base on x86_64
-https://aws.amazon.com/marketplace/server/procurement?productId=ef297a90-3ad0-4674-83b4-7f0ec07c39bb
+### Ubuntu 20.04 on WSL2 on Windows Server 2019 Base on x86_64
+Not yet tested. https://aws.amazon.com/marketplace/server/procurement?productId=ef297a90-3ad0-4674-83b4-7f0ec07c39bb.
 
-### Ubuntu on WSL2 on Windows Server 2016 Base on x86_64
-Not yet tested.
+t3.large
+
+https://docs.microsoft.com/en-us/windows/wsl/install-on-server
+
+Download Linux archive
+
+Find archive and extract all
+Run the program. 
+
 
 ### Debian 10 (Buster) on WSL2 on Windows Server 2016 Base on x86_64
 Not yet tested.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,106 @@
+# Testing pico-setup
+
+The tests validate that `pico_setup.sh` _seems_ to setup your system correctly. It can be fooled. It does not test that the SDK or tools themselves work correctly, just that the setup script did its thing.
+
+To execute the tests, first run `pico_setup.sh` from wherever you want to install the pico dev environment:
+```shell
+./pico_setup.sh
+```
+Logout and back in, so that your shell will pick up its environment variables. Then run the test from the same location as you ran `pico_setup.sh`:
+```shell
+./test/test
+```
+
+# What to test
+
+## Platform support
+Test support for the following platforms. The general process is:
+1. Start from a fresh OS image.
+1. Start the SSH service if necessary: `sudo /sbin/service ssh start`
+1. Push down the contents of the pico-setup repo from your dev host: `scp -r ~/git/raspberrypi/pico-setup/ pi@pi4:`
+1. SSH to the test host and execute the setup: `pico-setup/pico_setup.sh`
+1. Test the setup: "ssh pi@pi4 pico-setup/test/test"
+
+### Raspberry Pi OS Full (32-bit) on Raspberry Pi 4B
+This is the baseline platform, what most users will have.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### Raspberry Pi OS Full (64-bit) on Raspberry Pi 4B
+If all of the dependencies (APT repo, etc) are in good shape, this should work the same as the 32-bit OS, since we don't do anything explicitly for one or the other.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### Raspberry Pi OS Lite (32-bit) on Raspberry Pi 4B
+Should be the same as the full OS, but doesn't attempt to install VS Code, because there will be no XWindows.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### Ubuntu Desktop 20.10 (64-bit) on Raspberry Pi 4B
+Less common. Should work a lot like Raspberry Pi OS, but with a couple different package dependencies.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### Debian 10 (Buster) on Raspberry Pi 4B
+Less common. Should work a lot like Raspberry Pi OS, but with a couple different package dependencies.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### macOS Big Sur on Mac mini Intel
+Can be rented on EC2, but not as cheaply as the other platforms. You have to get a dedicated host, which currently costs $1.083/hour in us-west-2, with a minimum of 24 hours. You can launch and terminate instances all day on that dedicated host without extra cost, which is good for testing installers. Comes with Homebrew installed, which is nice.
+
+Default user is `ec2-user`. You will have to use sudo to set the user's password:
+```shell
+sudo -i
+passwd ec2-user
+```
+
+### Raspberry Pi Desktop on x86_64
+Not yet tested.
+
+### Ubuntu 20.10 on x86_64
+Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B08LQMCZGC?ref_=beagle&applicationId=AWS-Marketplace-Console) for pennies/hour. Recommend t3.micro with 8 GiB EBS volume. Default user is `ubuntu`. You will have to use sudo to set the user's password:
+```shell
+sudo -i
+passwd ubuntu
+```
+
+### Debian 10 (Buster) on x86_64
+Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B0859NK4HC?ref_=aws-mp-console-subscription-detail) for pennies/hour. Recommend t3.micro with 8 GiB EBS volume. Default user is `admin`. You will have to use sudo to set the user's password:
+```shell
+sudo -i
+passwd admin
+```
+
+### Ubuntu 20.10 on Graviton2
+Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B08LQMCZGC?ref_=beagle&applicationId=AWS-Marketplace-Console) for pennies/hour. Recommend t4g.micro with 8 GiB EBS volume. Default user is `ubuntu`. You will have to use sudo to set the user's password:
+```shell
+sudo -i
+passwd ubuntu
+```
+
+### Debian 10 (Buster) on Graviton2
+Can be rented on [EC2](https://aws.amazon.com/marketplace/pp/B0859NK4HC?ref_=aws-mp-console-subscription-detail) for pennies/hour. Recommend t3.micro with 8 GiB EBS volume. Default user is `admin`. You will have to use sudo to set the user's password:
+```shell
+sudo -i
+passwd admin
+```
+
+### Windows Server 2016 Base on x86_64
+https://aws.amazon.com/marketplace/server/procurement?productId=13c2dbc9-57fc-4958-922e-a1ba7e223b0d
+
+### Windows Server 2016 Base on x86_64
+https://aws.amazon.com/marketplace/server/procurement?productId=ef297a90-3ad0-4674-83b4-7f0ec07c39bb
+
+### Ubuntu on WSL2 on Windows Server 2016 Base on x86_64
+Not yet tested.
+
+### Debian 10 (Buster) on WSL2 on Windows Server 2016 Base on x86_64
+Not yet tested.
+
+## Scenarios
+Test some scenarios:
+* Shells: bash, zsh. It should be enough to switch shells and rerun the installer and test. You don't have to wipe the SD card/disk.
+* .profile or .zprofile doesn't end in newline
+* PWD containing space
+* Raspberry Pi OS Lite (32-bit) shouldn't install VS Code

--- a/test/README.md
+++ b/test/README.md
@@ -32,11 +32,18 @@ If all of the dependencies (APT repo, etc) are in good shape, this should work t
 Write fresh SD card with Raspberry Pi Imager.
 
 ### Raspberry Pi OS Lite (32-bit) on Raspberry Pi 4B
-Should be the same as the full OS. Currently, this will install Visual Studio Code, but that may change.
+Should be the same as the full OS, but doesn't install Visual Studio Code because there's no XWindows.
 
 Write fresh SD card with Raspberry Pi Imager.
 
 ### Ubuntu Desktop 20.10 (64-bit) on Raspberry Pi 4B
+Not yet tested.
+
+Less common. Should work a lot like Raspberry Pi OS, but with a couple different package dependencies.
+
+Write fresh SD card with Raspberry Pi Imager.
+
+### Ubuntu Server 20.10 (32-bit) on Raspberry Pi 4B
 Less common. Should work a lot like Raspberry Pi OS, but with a couple different package dependencies.
 
 Write fresh SD card with Raspberry Pi Imager.
@@ -89,25 +96,29 @@ passwd admin
 ### Windows Server 2016 Base on x86_64
 Not yet tested. See https://aws.amazon.com/marketplace/server/procurement?productId=13c2dbc9-57fc-4958-922e-a1ba7e223b0d.
 
-### Ubuntu 20.04 on WSL2 on Windows Server 2019 Base on x86_64
-Not yet tested. https://aws.amazon.com/marketplace/server/procurement?productId=ef297a90-3ad0-4674-83b4-7f0ec07c39bb.
+### Ubuntu 20.04 on WSL1 on Windows Server 2019 Base on x86_64
+Can be rented on [EC2](https://aws.amazon.com/marketplace/server/procurement?productId=ef297a90-3ad0-4674-83b4-7f0ec07c39bb) for pennies/hour. Recommend t3.large. Default user is `ec2-user`. Connect with Microsoft Remote Desktop.
 
-t3.large
+Install WSL according to https://docs.microsoft.com/en-us/windows/wsl/install-on-server. Install Ubuntu for WSL
 
-https://docs.microsoft.com/en-us/windows/wsl/install-on-server
+In the Linux shell:
+```shell
+wget https://raw.githubusercontent.com/raspberrypi/pico-setup/master/pico_setup.sh
+chmod +x pico_setup.sh
+./pico_setup.sh
+```
 
-Download Linux archive
+### Debian GNU/Linux 1.3.0.0 on WSL1 on Windows Server 2019 Base on x86_64
+Similar instructions as Ubuntu, but using the Debian WSL package and you'll have to explicitly install wget:
+```shell
+sudo apt update
+sudo apt install -y wget
+```
 
-Find archive and extract all
-Run the program. 
-
-
-### Debian 10 (Buster) on WSL2 on Windows Server 2016 Base on x86_64
-Not yet tested.
+Currently fails due to lack of python3.
 
 ## Scenarios
 Test some scenarios:
 * Shells: bash, zsh. It should be enough to switch shells and rerun the installer and test. You don't have to wipe the SD card/disk.
 * .profile or .zprofile doesn't end in newline
-* PWD containing space
-* Raspberry Pi OS Lite (32-bit) shouldn't install VS Code
+* PWD containing space. The script seems to handle it but a OpenOCD submodule, jimctl, doesn't.

--- a/test/test
+++ b/test/test
@@ -8,8 +8,6 @@ set -ex
 
 WORKING_DIR="$(pwd)/pico"
 
-<<<<<<< HEAD
-=======
 linux() {
     # Returns true iff this is running on Linux
     uname | grep -q "^Linux$"
@@ -28,15 +26,12 @@ ubuntu() {
     return ${?}
 }
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 mac() {
     # Returns true iff this is running on macOS and presumably Apple hardware
     uname | grep -q "^Darwin$"
     return ${?}
 }
 
-<<<<<<< HEAD
-=======
 raspberry_pi() {
     # Returns true iff this is running on a Raspberry Pi computer, regardless of the OS
     if [ -f /proc/cpuinfo ]; then
@@ -47,7 +42,6 @@ raspberry_pi() {
 }
 
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 fail() {
     # Outputs a failure message and exits with the error code output by the previous call.
     # All args are echoed as a failure message.
@@ -82,8 +76,6 @@ test_pico_sdk() {
     test "${PICO_SDK_PATH}" = "${WORKING_DIR}/pico-sdk" || fail
 }
 
-<<<<<<< HEAD
-=======
 test_uart() {
     # test that the UART is configured. Only works on Raspberry Pi OS on Raspberry Pi hardware.
     dpkg-query -s minicom || fail
@@ -92,7 +84,6 @@ test_uart() {
     grep -q "console=serial0" /boot/cmdline.txt && fail
 }
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 test_pico_examples() {
     test_git_repo pico-examples
 
@@ -143,16 +134,10 @@ test_vscode_linux() {
 }
 
 test_vscode_mac() {
-<<<<<<< HEAD
-    echo "This script can't tell whether Visual Studio Code is installed on macOS"
-}
-
-=======
     echo "Not yet implemented: testing Visual Studio Code on macOS"
 }
 
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 # execute tests
 if mac; then
     test_toolchain_mac
@@ -162,13 +147,10 @@ fi
 
 test_pico_sdk
 
-<<<<<<< HEAD
-=======
 if raspbian && raspberry_pi; then
     test_uart
 fi
 
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 test_pico_examples
 test_pico_extras
 test_pico_playground
@@ -178,13 +160,9 @@ test_picotool
 if mac; then
     test_vscode_mac
 else
-<<<<<<< HEAD
-    test_vscode_mac
-=======
     if dpkg-query -s xserver-xorg >> /dev/null && ! (debian || ubuntu); then
         test_vscode_linux
     fi
->>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 fi
 
 echo "Tests passed! 😁"

--- a/test/test
+++ b/test/test
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Executes the full test suite on the local host
+#
+# Configurations env vars:
+
+set -ex
+
+WORKING_DIR="$(pwd)/pico"
+
+mac() {
+    # Returns true iff this is running on macOS and presumably Apple hardware
+    uname | grep -q "^Darwin$"
+    return ${?}
+}
+
+fail() {
+    # Outputs a failure message and exits with the error code output by the previous call.
+    # All args are echoed as a failure message.
+
+    R="${?}"
+    echo "Tests failed! 😢"
+    if [ ${*} ]; then
+        echo "${*}"
+    fi
+    exit ${R}
+}
+
+test_git_repo() {
+    # tests that the given relative path exists and is a git repo
+    git -C ${WORKING_DIR}/${1} status || fail
+}
+
+test_toolchain_linux() {
+    # test that the expected packages are installed
+    dpkg-query -s git cmake gcc-arm-none-eabi build-essential gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev || fail
+}
+
+test_toolchain_mac() {
+    # test that the expected packages are installed
+    brew list git cmake pkg-config libtool automake libusb wget pkg-config gcc texinfo arm-none-eabi-gcc
+}
+
+test_pico_sdk() {
+    test_git_repo pico-sdk
+
+    # test that the SDK env var is set and correct
+    test "${PICO_SDK_PATH}" = "${WORKING_DIR}/pico-sdk" || fail
+}
+
+test_pico_examples() {
+    test_git_repo pico-examples
+
+    # test that blink is built
+    test -f ${WORKING_DIR}/pico-examples/build/blink/blink.uf2 || fail
+
+    # test that hello_serial is built
+    test -f ${WORKING_DIR}/pico-examples/build/hello_world/serial/hello_serial.uf2 || fail
+
+    # test that hello_usb is built
+    test -f ${WORKING_DIR}/pico-examples/build/hello_world/usb/hello_usb.uf2 || fail
+}
+
+test_pico_extras() {
+    test_git_repo pico-extras
+}
+
+test_pico_playground() {
+    test_git_repo pico-playground
+}
+
+test_picotool() {
+    test_git_repo picotool
+
+    # test that the binary is built
+    test -x ${WORKING_DIR}/picotool/build/picotool || fail
+
+    # test that picotool is installed in the expected location
+    test -x /usr/local/bin/picotool || fail
+}
+
+test_openocd() {
+    test_git_repo openocd
+
+    # test that the binary is built
+    test -x ${WORKING_DIR}/openocd/src/openocd || fail
+}
+
+test_picoprobe() {
+    test_git_repo picoprobe || fail
+
+    # test that the binary is built
+    test -f ${WORKING_DIR}/picoprobe/build/picoprobe.uf2 || fail
+}
+
+test_vscode_linux() {
+    dpkg-query -s code || fail
+}
+
+test_vscode_mac() {
+    echo "This script can't tell whether Visual Studio Code is installed on macOS"
+}
+
+# execute tests
+if mac; then
+    test_toolchain_mac
+else
+    test_toolchain_linux
+fi
+
+test_pico_sdk
+
+test_pico_examples
+test_pico_extras
+test_pico_playground
+test_openocd
+test_picoprobe
+test_picotool
+if mac; then
+    test_vscode_mac
+else
+    test_vscode_mac
+fi
+
+echo "Tests passed! 😁"

--- a/test/test
+++ b/test/test
@@ -8,12 +8,46 @@ set -ex
 
 WORKING_DIR="$(pwd)/pico"
 
+<<<<<<< HEAD
+=======
+linux() {
+    # Returns true iff this is running on Linux
+    uname | grep -q "^Linux$"
+    return ${?}
+}
+
+debian() {
+    # Returns true iff this is running on Debian
+    grep -q '^NAME="Debian GNU/Linux"$' /etc/os-release
+    return ${?}
+}
+
+ubuntu() {
+    # Returns true iff this is running on Ubuntu
+    grep -q '^NAME="Ubuntu"$' /etc/os-release
+    return ${?}
+}
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 mac() {
     # Returns true iff this is running on macOS and presumably Apple hardware
     uname | grep -q "^Darwin$"
     return ${?}
 }
 
+<<<<<<< HEAD
+=======
+raspberry_pi() {
+    # Returns true iff this is running on a Raspberry Pi computer, regardless of the OS
+    if [ -f /proc/cpuinfo ]; then
+        grep -q "^Model\s*: Raspberry Pi" /proc/cpuinfo
+        return ${?}
+    fi
+    return 1
+}
+
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 fail() {
     # Outputs a failure message and exits with the error code output by the previous call.
     # All args are echoed as a failure message.
@@ -48,6 +82,17 @@ test_pico_sdk() {
     test "${PICO_SDK_PATH}" = "${WORKING_DIR}/pico-sdk" || fail
 }
 
+<<<<<<< HEAD
+=======
+test_uart() {
+    # test that the UART is configured. Only works on Raspberry Pi OS on Raspberry Pi hardware.
+    dpkg-query -s minicom || fail
+    grep -q "enable_uart=1" /boot/config.txt || fail
+    # note that the test for console=serial0 tests for the absence of a string
+    grep -q "console=serial0" /boot/cmdline.txt && fail
+}
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 test_pico_examples() {
     test_git_repo pico-examples
 
@@ -98,9 +143,16 @@ test_vscode_linux() {
 }
 
 test_vscode_mac() {
+<<<<<<< HEAD
     echo "This script can't tell whether Visual Studio Code is installed on macOS"
 }
 
+=======
+    echo "Not yet implemented: testing Visual Studio Code on macOS"
+}
+
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 # execute tests
 if mac; then
     test_toolchain_mac
@@ -110,6 +162,13 @@ fi
 
 test_pico_sdk
 
+<<<<<<< HEAD
+=======
+if raspbian && raspberry_pi; then
+    test_uart
+fi
+
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 test_pico_examples
 test_pico_extras
 test_pico_playground
@@ -119,7 +178,13 @@ test_picotool
 if mac; then
     test_vscode_mac
 else
+<<<<<<< HEAD
     test_vscode_mac
+=======
+    if dpkg-query -s xserver-xorg >> /dev/null && ! (debian || ubuntu); then
+        test_vscode_linux
+    fi
+>>>>>>> 4f2c6f4... Major rewrite. Added support for macOS, Debian, Ubuntu. Added test/validation script.
 fi
 
 echo "Tests passed! 😁"


### PR DESCRIPTION
This is a complete overhaul of pico-setup. I'd like to specifically point out my appreciation for the first version, which was very helpful to understand the requirements. Thank you, @liamfraser. I have also incorporated changes are in others' pull requests, but have not yet been merged. Thank you to those authors as well.

# Design
The setup actions are grouped into phases. There's a fair bit going on in this script, and I think it's easier to understand with some sensible structure. The phases approximately follow the Getting Started documentation, adjusted for the non-interactive use case.
1. Preflight check
2. Setup minimum dev environment
3. Setup the tutorials
4. Setup recommended tools

This code is factored into functions, where the previous version was a straight-through script. This code certainly is longer, but should be very easy to read, understand, and modify.

# Testing
This version adds some automation for testing. See `test/` for details.

# Documentation
This version adds `README.md` and `LICENSE.txt`. The license is copied from the pico-examples, including the American spelling of "license". :)

# Compatibility
This update works with a number of OS and hardware platforms (see `README.md`). It should work on all up-to-date derivatives of Debian, as the key prerequisite is APT. I've tested it on a number of combinations and left notes (see `test/README.md`). I have have not exhaustively tested since the last modification, so it's possible that I broke something. Still, it's fair to say it supports lots of platforms.

This should resolve these issues:
* https://github.com/raspberrypi/pico-setup/issues/19
* https://github.com/raspberrypi/pico-setup/issues/16
* https://github.com/raspberrypi/pico-setup/issues/15

# Fixes for known issues
## .bashrc
This version puts the environment variables in `.z?profile`, correctly handling both bash and zsh, which is particularly relevant as it's the default shell on macOS. https://github.com/raspberrypi/pico-setup/issues/13, https://github.com/raspberrypi/pico-setup/pull/14

Additionally, the new code handles the case where the file didn't end in a newline. https://github.com/raspberrypi/pico-setup/issues/12

## Idempotence
This version is idempotent with regard to `mkdir` specifically (https://github.com/raspberrypi/pico-setup/issues/10, https://github.com/raspberrypi/pico-setup/pull/11) and generally picks up where it left off when rerun (https://github.com/raspberrypi/pico-setup/pull/6). If interrupted with signal or transient failure, it's fine to rerun.

## Visual Studio Code
The script installs VS Code when it looks like there's a local XWindows server. https://github.com/raspberrypi/pico-setup/issues/7

But--the features around Visual Studio Code only work on Raspberry Pi OS, not Debian, Ubuntu or macOS. This is mostly because the Raspberry Pi OS repos already have VS Code and it installs nicely.

## Paths with spaces
I think this version handles paths with spaces correctly, but it does download all git submodules, and one of openocd's submodules doesn't handle spaces. https://github.com/raspberrypi/pico-setup/issues/17, https://github.com/raspberrypi/pico-setup/pull/18

# Features not added
## UI
The design of the code should lend itself nicely to adding an interactive interface or otherwise de/selecting features, but I haven't implemented this and removed the `SKIP*` method because I didn't like it. I think if it's important, a better mechanism would be command line switches.

# Your review is appreciated
Feedback welcome, as always. :)
