### PR TITLE
Added PkgConfig dependency for picotool

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -17,7 +17,7 @@ OUTDIR="$(pwd)/pico"
 
 # Install dependencies
 GIT_DEPS="git"
-SDK_DEPS="cmake gcc-arm-none-eabi gcc g++"
+SDK_DEPS="cmake gcc-arm-none-eabi gcc g++ pkg-config"
 OPENOCD_DEPS="gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
 # Wget to download the deb
 VSCODE_DEPS="wget"


### PR DESCRIPTION
If pkg-config is not installed, picotool cannot find libusb-1.0-0 and the pico_setup.sh fails with an error.  I believe this is the simplest fix to solve the issue within Ubuntu 20.04 for Raspberry Pi 4 64-bit.