### PR TITLE
Initialise picoprobe submodules

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -99,6 +99,7 @@ do
 
     # Build both
     cd $DEST
+    git submodule update --init
     mkdir build
     cd build
     cmake ../


### PR DESCRIPTION
Picoprobe now pulls in CMSIS and FreeRTOS as submodules

Fixes #24 