### PR TITLE
update raspi-config nonint commands

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -160,6 +160,11 @@ if [[ "$SKIP_UART" == 1 ]]; then
 else
     sudo apt install -y $UART_DEPS
     echo "Disabling Linux serial console (UART) so we can use it for pico"
-    sudo raspi-config nonint do_serial 2
+
+    # Enable UART hardware
+    sudo raspi-config nonint do_serial_hw 0
+    # Disable console over serial port
+    sudo raspi-config nonint do_serial_cons 1
+
     echo "You must run sudo reboot to finish UART setup"
 fi


### PR DESCRIPTION
Updating script to use new raspi-config nonint commands. See issue #29

Previously, enabling UART 1 and disabling the serial terminal was done with a single command, now you use:
`raspi-config nonint do_serial_hw 0`
and
`raspi-config nonint do_serial_cons 1`