### PR TITLE
Allows do use github.com SSH authorization when downloading repos and submodules

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -43,6 +43,17 @@ cd $OUTDIR
 
 # Clone sw repos
 GITHUB_PREFIX="https://github.com/raspberrypi/"
+echo "Checking if github.com ssh authentication is used"
+USING_SSH_ON_GITHUB=0
+if [ -e ~/.ssh/config ]; then
+	grep -q github.com ~/.ssh/config && export USING_SSH_ON_GITHUB=1
+fi
+
+# if the user is using ssh on github then change github prefix according to ssh
+if [[ "$USING_SSH_ON_GITHUB" == 1 ]]; then
+	export GITHUB_PREFIX="git@github.com:raspberrypi/"
+fi
+
 GITHUB_SUFFIX=".git"
 SDK_BRANCH="master"
 
@@ -59,6 +70,11 @@ do
 
         # Any submodules
         cd $DEST
+	if [[ "$USING_SSH_ON_GITHUB" == 1 ]]; then
+	    if [ -e .gitmodules ]; then
+	        sed -i 's/https:\/\/github.com\//git@github.com:/' .gitmodules
+	    fi
+	fi
         git submodule update --init
         cd $OUTDIR
 
@@ -105,6 +121,11 @@ do
 
     # Build both
     cd $DEST
+    if [[ "$USING_SSH_ON_GITHUB" == 1 ]]; then
+	if [ -e .gitmodules ]; then
+	    sed -i 's/https:\/\/github.com\//git@github.com:/' .gitmodules
+	fi
+    fi
     git submodule update --init
     mkdir build
     cd build


### PR DESCRIPTION
This script is updated to use SSH to handle downloading errors from Gihub when using https, like this "Fork for correction 'error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)' and SSH github.com authentication".

If the user has ~/.ssh/config file and it contains 'github.com' string then SSH is used.

The script is tested.