### PR TITLE
Leverage cmake directory management and targets

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -76,22 +76,18 @@ cd $OUTDIR
 source ~/.bashrc
 
 # Build blink and hello world for pico and pico2
-cd pico-examples
 for board in pico pico2
 do
+    # Build dirs will be outside of pico-* dirs
+    # so that it is not lost among all the subfolders
+    # of pico-examples
     build_dir=build_$board
-    mkdir $build_dir
-    cd $build_dir
-    cmake ../ -DPICO_BOARD=$board -DCMAKE_BUILD_TYPE=Debug
-    for e in blink hello_world
-    do
-        echo "Building $e for $board"
-        cd $e
-        make -j$JNUM
-        cd ..
-    done
-
-    cd ..
+    if [ -d $build_dir ]; then
+        echo "$build_dir already exists so skipping"
+    else
+        cmake ./pico-examples -B $build_dir -DPICO_BOARD=$board -DCMAKE_BUILD_TYPE=Debug
+        cmake --build $build_dir --target blink hello_serial hello_usb
+    fi
 done
 
 cd $OUTDIR


### PR DESCRIPTION
* use `-B <path_to_build_folder>` to manage build folder, instead of manually creating directory and going there.
* use `--target ...` to avoid delving into specific subfolder and calling `make`instead of cmake.
* The build folders are created **outside** of pico-* folders, so that they are not lost among the various subfolders of the pico-examples folder.