### PR TITLE
Add soon-to-be required OpenOCD package dependencies

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -19,7 +19,7 @@ OUTDIR="$(pwd)/pico"
 # Install dependencies
 GIT_DEPS="git"
 SDK_DEPS="cmake gcc-arm-none-eabi gcc g++"
-OPENOCD_DEPS="gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev"
+OPENOCD_DEPS="gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev libjim-dev pkg-config"
 VSCODE_DEPS="code"
 UART_DEPS="minicom"
 


### PR DESCRIPTION
pkg-config is mentioned as a "may be required" but all that generates is bug reports when not installed.
OpenOCD no longer self-builds jimtcl and relies on an OS package by default.