### PR TITLE
Ensure that we build picotool from the same branch-name as pico-sdk

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -80,7 +80,11 @@ for REPO in picotool debugprobe
 do
     DEST="$OUTDIR/$REPO"
     REPO_URL="${GITHUB_PREFIX}${REPO}${GITHUB_SUFFIX}"
-    git clone $REPO_URL
+    if [[ "$REPO" == "picotool" ]]; then
+      git clone -b $SDK_BRANCH $REPO_URL
+    else
+      git clone $REPO_URL
+    fi
 
     # Build both
     cd $DEST


### PR DESCRIPTION
If the user modifies this script to checkout the `develop` version of pico-sdk, IIRC they'll also need the `develop` version of picotool.