### PR TITLE
Remove git-lfs from script dependencies

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -17,7 +17,7 @@ JNUM=4
 OUTDIR="$(pwd)/pico"
 
 # Install dependencies
-GIT_DEPS="git git-lfs"
+GIT_DEPS="git"
 SDK_DEPS="cmake gcc-arm-none-eabi gcc g++ ninja-build"
 OPENOCD_DEPS="gdb-multiarch automake autoconf build-essential texinfo libtool libftdi-dev libusb-1.0-0-dev libjim-dev pkg-config libgpiod-dev"
 UART_DEPS="minicom"


### PR DESCRIPTION
This reverts #47

`git-lfs` is no longer needed after this update to debugprobe https://github.com/raspberrypi/debugprobe/pull/176